### PR TITLE
close the code block near the end of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,6 +771,7 @@ async def launch(game_id):
 
 if __name__ == '__main__':
     asyncio.run(launch(game_id=str(random.randint(1, 1000))))
+```
 
 ## License
 


### PR DESCRIPTION
Noticed that the license information appears to be a part of the last code block.

Very minor but why not fix it now instead of finding out in the future when you want to append something…